### PR TITLE
Dashboard Page 만들기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
-import React from "react";
 import { Routes, Route } from "react-router-dom";
 import LoginPage from "./pages/auth/login";
+import DashBoardPage from "./pages/dashboard";
 
 function App() {
   return (
     <Routes>
       <Route path="/auth/login" element={<LoginPage />} />
+      <Route path="/dashboard" element={<DashBoardPage />} />
     </Routes>
   );
 }

--- a/src/components/dashboard/AppBar.tsx
+++ b/src/components/dashboard/AppBar.tsx
@@ -1,0 +1,29 @@
+import { VFC } from "react";
+import MuiAppBar from "@mui/material/AppBar";
+import Toolbar from "@mui/material/Toolbar";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+import AccountCircleSharpIcon from "@mui/icons-material/AccountCircleSharp";
+
+const AppBar: VFC = () => {
+  return (
+    <MuiAppBar position="absolute">
+      <Toolbar sx={{ pr: "24px" }}>
+        <Typography
+          component="h1"
+          variant="h6"
+          color="inherit"
+          noWrap
+          sx={{ flexGrow: 1 }}
+        >
+          Dashboard
+        </Typography>
+        <IconButton color="inherit">
+          <AccountCircleSharpIcon />
+        </IconButton>
+      </Toolbar>
+    </MuiAppBar>
+  );
+};
+
+export default AppBar;

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -1,0 +1,21 @@
+import { VFC } from "react";
+import Box from "@mui/material/Box";
+
+const Dashboard: VFC = () => {
+  return (
+    <Box
+      component="main"
+      sx={{
+        backgroundColor: (theme) =>
+          theme.palette.mode === "light"
+            ? theme.palette.grey[100]
+            : theme.palette.grey[900],
+        flexGrow: 1,
+        height: "100vh",
+        overflow: "auto",
+      }}
+    ></Box>
+  );
+};
+
+export default Dashboard;

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,21 +1,16 @@
 import { VFC } from "react";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
 import Box from "@mui/material/Box";
 import CssBaseline from "@mui/material/CssBaseline";
 import AppBar from "components/dashboard/AppBar";
 import Dashboard from "components/dashboard/Dashboard";
 
-const mdTheme = createTheme();
-
 const DashboardPage: VFC = () => {
   return (
-    <ThemeProvider theme={mdTheme}>
-      <Box sx={{ display: "flex" }}>
-        <CssBaseline />
-        <AppBar />
-        <Dashboard />
-      </Box>
-    </ThemeProvider>
+    <Box sx={{ display: "flex" }}>
+      <CssBaseline />
+      <AppBar />
+      <Dashboard />
+    </Box>
   );
 };
 

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,0 +1,22 @@
+import { VFC } from "react";
+import { createTheme, ThemeProvider } from "@mui/material/styles";
+import Box from "@mui/material/Box";
+import CssBaseline from "@mui/material/CssBaseline";
+import AppBar from "components/dashboard/AppBar";
+import Dashboard from "components/dashboard/Dashboard";
+
+const mdTheme = createTheme();
+
+const DashboardPage: VFC = () => {
+  return (
+    <ThemeProvider theme={mdTheme}>
+      <Box sx={{ display: "flex" }}>
+        <CssBaseline />
+        <AppBar />
+        <Dashboard />
+      </Box>
+    </ThemeProvider>
+  );
+};
+
+export default DashboardPage;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -18,9 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "src"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
<img width="625" alt="Screen Shot 2022-04-07 at 8 51 58 PM" src="https://user-images.githubusercontent.com/53519832/162192497-93fa2256-35ef-4a21-980b-7becdbda11c5.png">
위에 Dashboard 문구와 profile icon이 있는 파란 영역인 AppBar 컴포넌트와 아래 영역의 Dashboard 컴포넌트를 생성하고 DashboardPage에 추가함.

close #2 